### PR TITLE
Fix Setuptools find_packages exclude option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,6 @@ jobs:
           pip3 install grpcio-tools
       - name: prepare to publish
         run: |
-          ## dirty hack: for some reason, options.packages.find.exclude
-          ## directive in setup.cfg doesn't work properly
-          rm -rf src/tests src/test.py
           python3 setup.py sdist
           python3 setup.py bdist_wheel
       - name: publish

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,4 +21,4 @@ install_requires=
 
 [options.packages.find]
 where = src
-exclude = src.tests
+exclude = tests*


### PR DESCRIPTION
## Description
Fix Setuptools find_packages exclude option to remove packaging hacks in the release workflow.


## Details on packaging diffs
I've compared the list of files of three different wheels:

- `before.txt`: the wheel built from a commit (d359fd9) before this PR
- `after.txt`: the wheel built from a commit in this (00197eb) PR
- `released.txt`: the wheel already published to [PyPI](https://pypi.org/project/vald-client-python/1.7.8/)

```
$ git rev-parse --short HEAD
d359fd9
$ pyproject-build
$ tar -tf dist/vald_client_python-1.7.8-py3-none-any.whl > before.txt

$ vi setup.cfg

$ git rev-parse --short HEAD
00197eb
$ pyproject-build
$ tar -tf dist/vald_client_python-1.7.8-py3-none-any.whl > after.txt

$ curl -s https://files.pythonhosted.org/packages/50/24/d46e0ec7ee204e8e28a388aee726cdaf6d427029953e8c977706ef4997f7/vald_client_python-1.7.8-py3-none-any.whl | tar -t > released.txt

$ diff -u before.txt after.txt
--- before.txt	2023-10-03 20:21:37.000000000 +0900
+++ after.txt	2023-10-03 20:32:28.000000000 +0900
@@ -2,7 +2,6 @@
 google/api/annotations_pb2_grpc.py
 google/rpc/status_pb2.py
 google/rpc/status_pb2_grpc.py
-tests/test_e2e.py
 vald/v1/agent/core/agent_pb2.py
 vald/v1/agent/core/agent_pb2_grpc.py
 vald/v1/filter/egress/egress_filter_pb2.py

$ diff -u released.txt after.txt
```

### before.txt

```
google/api/annotations_pb2.py
google/api/annotations_pb2_grpc.py
google/rpc/status_pb2.py
google/rpc/status_pb2_grpc.py
tests/test_e2e.py
vald/v1/agent/core/agent_pb2.py
vald/v1/agent/core/agent_pb2_grpc.py
vald/v1/filter/egress/egress_filter_pb2.py
vald/v1/filter/egress/egress_filter_pb2_grpc.py
vald/v1/filter/ingress/ingress_filter_pb2.py
vald/v1/filter/ingress/ingress_filter_pb2_grpc.py
vald/v1/payload/payload_pb2.py
vald/v1/payload/payload_pb2_grpc.py
vald/v1/vald/filter_pb2.py
vald/v1/vald/filter_pb2_grpc.py
vald/v1/vald/insert_pb2.py
vald/v1/vald/insert_pb2_grpc.py
vald/v1/vald/object_pb2.py
vald/v1/vald/object_pb2_grpc.py
vald/v1/vald/remove_pb2.py
vald/v1/vald/remove_pb2_grpc.py
vald/v1/vald/search_pb2.py
vald/v1/vald/search_pb2_grpc.py
vald/v1/vald/update_pb2.py
vald/v1/vald/update_pb2_grpc.py
vald/v1/vald/upsert_pb2.py
vald/v1/vald/upsert_pb2_grpc.py
validate/validate_pb2.py
validate/validate_pb2_grpc.py
vtproto/ext_pb2.py
vtproto/ext_pb2_grpc.py
vald_client_python-1.7.8.dist-info/LICENSE
vald_client_python-1.7.8.dist-info/METADATA
vald_client_python-1.7.8.dist-info/WHEEL
vald_client_python-1.7.8.dist-info/top_level.txt
vald_client_python-1.7.8.dist-info/RECORD
```

### after.txt
```
google/api/annotations_pb2.py
google/api/annotations_pb2_grpc.py
google/rpc/status_pb2.py
google/rpc/status_pb2_grpc.py
vald/v1/agent/core/agent_pb2.py
vald/v1/agent/core/agent_pb2_grpc.py
vald/v1/filter/egress/egress_filter_pb2.py
vald/v1/filter/egress/egress_filter_pb2_grpc.py
vald/v1/filter/ingress/ingress_filter_pb2.py
vald/v1/filter/ingress/ingress_filter_pb2_grpc.py
vald/v1/payload/payload_pb2.py
vald/v1/payload/payload_pb2_grpc.py
vald/v1/vald/filter_pb2.py
vald/v1/vald/filter_pb2_grpc.py
vald/v1/vald/insert_pb2.py
vald/v1/vald/insert_pb2_grpc.py
vald/v1/vald/object_pb2.py
vald/v1/vald/object_pb2_grpc.py
vald/v1/vald/remove_pb2.py
vald/v1/vald/remove_pb2_grpc.py
vald/v1/vald/search_pb2.py
vald/v1/vald/search_pb2_grpc.py
vald/v1/vald/update_pb2.py
vald/v1/vald/update_pb2_grpc.py
vald/v1/vald/upsert_pb2.py
vald/v1/vald/upsert_pb2_grpc.py
validate/validate_pb2.py
validate/validate_pb2_grpc.py
vtproto/ext_pb2.py
vtproto/ext_pb2_grpc.py
vald_client_python-1.7.8.dist-info/LICENSE
vald_client_python-1.7.8.dist-info/METADATA
vald_client_python-1.7.8.dist-info/WHEEL
vald_client_python-1.7.8.dist-info/top_level.txt
vald_client_python-1.7.8.dist-info/RECORD
```

### released.txt
```
google/api/annotations_pb2.py
google/api/annotations_pb2_grpc.py
google/rpc/status_pb2.py
google/rpc/status_pb2_grpc.py
vald/v1/agent/core/agent_pb2.py
vald/v1/agent/core/agent_pb2_grpc.py
vald/v1/filter/egress/egress_filter_pb2.py
vald/v1/filter/egress/egress_filter_pb2_grpc.py
vald/v1/filter/ingress/ingress_filter_pb2.py
vald/v1/filter/ingress/ingress_filter_pb2_grpc.py
vald/v1/payload/payload_pb2.py
vald/v1/payload/payload_pb2_grpc.py
vald/v1/vald/filter_pb2.py
vald/v1/vald/filter_pb2_grpc.py
vald/v1/vald/insert_pb2.py
vald/v1/vald/insert_pb2_grpc.py
vald/v1/vald/object_pb2.py
vald/v1/vald/object_pb2_grpc.py
vald/v1/vald/remove_pb2.py
vald/v1/vald/remove_pb2_grpc.py
vald/v1/vald/search_pb2.py
vald/v1/vald/search_pb2_grpc.py
vald/v1/vald/update_pb2.py
vald/v1/vald/update_pb2_grpc.py
vald/v1/vald/upsert_pb2.py
vald/v1/vald/upsert_pb2_grpc.py
validate/validate_pb2.py
validate/validate_pb2_grpc.py
vtproto/ext_pb2.py
vtproto/ext_pb2_grpc.py
vald_client_python-1.7.8.dist-info/LICENSE
vald_client_python-1.7.8.dist-info/METADATA
vald_client_python-1.7.8.dist-info/WHEEL
vald_client_python-1.7.8.dist-info/top_level.txt
vald_client_python-1.7.8.dist-info/RECORD
```