### PR TITLE
Add workflows to automatically dependencies update and merge it.

### DIFF
--- a/.github/dependabot-cli.yaml
+++ b/.github/dependabot-cli.yaml
@@ -1,0 +1,14 @@
+job:
+  package-manager: pip
+  allowed-updates:
+    - update-type: all
+  dependency-groups:
+    - name: pip
+      rules:
+        patterns:
+          - "*"
+  source:
+    directories:
+      - "/"
+    provider: github
+    repo: vdaas/vald-client-python

--- a/.github/workflows/backport-deps.yaml
+++ b/.github/workflows/backport-deps.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: "Run backport deps update PR"
+on:
+  push:
+    branches:
+      - main
+jobs:
+  backport:
+    uses: vdaas/vald-client-ci/.github/workflows/_backport-deps.yaml@main
+    secrets:
+      CI_TOKEN: ${{ secrets.CI_TOKEN }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: "Run automatically merge bot PR"
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    uses: vdaas/vald-client-ci/.github/workflows/_pr-auto-merge.yaml@main
+    with:
+      client_type: python
+    secrets:
+      CI_TOKEN: ${{ secrets.CI_TOKEN }}

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Update npm dependencies
+
+on:
+  # TODO: delete it before merge.
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *"
+jobs:
+  # update:
+  #   uses: vdaas/vald-client-ci/.github/workflows/_update-deps.yaml@main
+  #   with:
+  #     config_file_path: .github/dependabot-cli.yaml
+  #     pr_branch_name: chore/update-pip
+  #   secrets:
+  #     CI_USER: ${{ secrets.CI_USER }}
+  #     CI_TOKEN: ${{ secrets.CI_TOKEN }}
+  #     GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+      - name: Set Git config
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - uses: vdaas/vald-client-ci/.github/actions/dependabot@main
+        with:
+          config_file_path: .github/dependabot-cli.yaml
+      # NOTE: When running dependabot cli, if the gpg action is set before the dependabot action, it fails during Node.js dependency updates
+      - uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+      - name: Check difference
+        id: check_diff
+        run: |
+          if git diff --quiet --exit-code; then
+            echo "Nothing updated"
+          else
+            git diff && git status
+            echo "HAS_GIT_DIFF=true" >> $GITHUB_OUTPUT
+          fi
+      - uses: vdaas/vald-client-ci/.github/actions/e2e@main
+        with:
+          client_type: python

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -16,8 +16,6 @@
 name: Update npm dependencies
 
 on:
-  # TODO: delete it before merge.
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 12 * * *"

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -22,43 +22,12 @@ on:
   schedule:
     - cron: "0 12 * * *"
 jobs:
-  # update:
-  #   uses: vdaas/vald-client-ci/.github/workflows/_update-deps.yaml@main
-  #   with:
-  #     config_file_path: .github/dependabot-cli.yaml
-  #     pr_branch_name: chore/update-pip
-  #   secrets:
-  #     CI_USER: ${{ secrets.CI_USER }}
-  #     CI_TOKEN: ${{ secrets.CI_TOKEN }}
-  #     GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
   update:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.CI_TOKEN }}
-      - name: Set Git config
-        run: |
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}
-      - uses: vdaas/vald-client-ci/.github/actions/dependabot@main
-        with:
-          config_file_path: .github/dependabot-cli.yaml
-      # NOTE: When running dependabot cli, if the gpg action is set before the dependabot action, it fails during Node.js dependency updates
-      - uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-      - name: Check difference
-        id: check_diff
-        run: |
-          if git diff --quiet --exit-code; then
-            echo "Nothing updated"
-          else
-            git diff && git status
-            echo "HAS_GIT_DIFF=true" >> $GITHUB_OUTPUT
-          fi
-      - uses: vdaas/vald-client-ci/.github/actions/e2e@main
-        with:
-          client_type: python
+    uses: vdaas/vald-client-ci/.github/workflows/_update-deps.yaml@main
+    with:
+      config_file_path: .github/dependabot-cli.yaml
+      pr_branch_name: chore/update-pip
+    secrets:
+      CI_USER: ${{ secrets.CI_USER }}
+      CI_TOKEN: ${{ secrets.CI_TOKEN }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-name: Update dependencies
+name: Update pip dependencies
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-name: Update npm dependencies
+name: Update dependencies
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
There are workflows to update the dependency in [vald-client-ci](https://github.com/vdaas/vald-client-ci) and then create a PR, which is automatically merged if the e2e test passes.
In this PR, I use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configured Dependabot for managing `pip` packages with specific update and dependency rules.
  - Introduced a workflow to backport dependencies on pushes to the `main` branch.
  - Added an auto-merge bot for pull requests to streamline the merge process.
  - Implemented a workflow to automatically update npm dependencies regularly or manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->