### PR TITLE
Add trusted host settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,11 @@ ci/deps/install: proto/deps/install
 		libprotobuf-dev \
 		libprotoc-dev \
 		protobuf-compiler
-	$(PYTHON) -m pip install --upgrade pip setuptools wheel
+	$(PYTHON) -m pip install \
+		--trusted-host pypi.python.org \
+		--trusted-host files.pythonhosted.org \
+		--trusted-host pypi.org \
+		--upgrade pip setuptools wheel
 	$(PIP) install grpcio-tools
 
 .PHONY: ci/deps/update


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the installation command for Python packages to include trusted hosts, improving reliability and security in package installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->